### PR TITLE
fix: mail.smtp 값 상수 삭제

### DIFF
--- a/src/main/java/com/example/travelshooting/common/Const.java
+++ b/src/main/java/com/example/travelshooting/common/Const.java
@@ -15,10 +15,6 @@ public class Const {
     public static final String KAKAO_PAY_HEADER = "SECRET_KEY";
     public static final String KAKAO_MAP_HEADER = "KakaoAK";
 
-    // 메일
-    public static final boolean SMTP_AUTH = true;
-    public static final boolean SMTP_STARTTLS = true;
-
     // 예약 메일 제목
     public static final String USER_RESERVATION_APPLY_SUBJECT = "예약 신청이 완료되었습니다.";
     public static final String USER_RESERVATION_APPROVED_SUBJECT = "예약이 승인되었습니다.";

--- a/src/main/java/com/example/travelshooting/config/MailConfig.java
+++ b/src/main/java/com/example/travelshooting/config/MailConfig.java
@@ -33,8 +33,8 @@ public class MailConfig {
         mailSender.setPassword(password);
 
         Properties properties = mailSender.getJavaMailProperties();
-        properties.put("mail.smtp.auth", Const.SMTP_AUTH);
-        properties.put("mail.smtp.starttls.enable", Const.SMTP_STARTTLS);
+        properties.put("mail.smtp.auth", true);
+        properties.put("mail.smtp.starttls.enable", true);
         properties.put("mail.smtp.timeout", Const.SMTP_TIMEOUT);
         properties.put("mail.smtp.connectiontimeout", Const.SMTP_TIMEOUT);
 


### PR DESCRIPTION
보안 인증이므로 false 할 일이 없기 때문에 true로 설정