### PR TITLE
fix: 알림 저장 로직 수정

### DIFF
--- a/src/main/java/com/example/travelshooting/enums/NotificationStatus.java
+++ b/src/main/java/com/example/travelshooting/enums/NotificationStatus.java
@@ -2,6 +2,5 @@ package com.example.travelshooting.enums;
 
 public enum NotificationStatus {
     PENDING,
-    SENT,
-    FAILED;
+    SENT;
 }

--- a/src/main/java/com/example/travelshooting/notification/service/ReservationMailService.java
+++ b/src/main/java/com/example/travelshooting/notification/service/ReservationMailService.java
@@ -32,11 +32,8 @@ public class ReservationMailService {
         String content = mailContent(user, product, part, reservation, userName);
         mailService.sendMail(user.getEmail(), details.subject(), content);
 
-        try {
-            notificationService.save(new Notification(user, DomainType.RESERVATION, reservation.getId(), details.subject(), NotificationStatus.SENT, details.type()));
-        } catch (Exception e) {
-            notificationService.save(new Notification(user, DomainType.RESERVATION, reservation.getId(), details.subject(), NotificationStatus.FAILED, details.type()));
-        }
+        // 알림 저장
+        notificationService.save(new Notification(user, DomainType.RESERVATION, reservation.getId(), details.subject(), NotificationStatus.SENT, details.type()));
     }
 
     // 예약 메일 내용에 들어갈 데이터


### PR DESCRIPTION
- 메일 전송 실패하면 알림 저장할 때, FAILED 상태 처리로 저장시킬려 했는데, catch 구문으로 들어가면 결국 'FAILED'라는 상태값 자체도 DB에 저장되지 않을 거 같아 로그 저장식으로 수정